### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/justinbegeman/585509e5-73a2-4bd0-9264-6b32f9a098c7/12bcbf79-9a4f-4aa4-aeca-0f3d0b831c04/_apis/work/boardbadge/6708ac38-aae5-4a7e-b642-79ecaf60f24b)](https://dev.azure.com/justinbegeman/585509e5-73a2-4bd0-9264-6b32f9a098c7/_boards/board/t/12bcbf79-9a4f-4aa4-aeca-0f3d0b831c04/Microsoft.RequirementCategory)
 # Tic Tac Toe Game
 
 Learn GitHub Actions through a fun little game.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/justinbegeman/585509e5-73a2-4bd0-9264-6b32f9a098c7/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.